### PR TITLE
Use latest-release image for updated node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following table lists the configurable parameters of the Tezos chart and the
 Parameter                       | Description                                       | Default
 ------------------------------- | ------------------------------------------------- | ----------------------------------------------------------
 `image.repository`              | Image source repository name                      | `tezos/tezos`
-`image.tag`                     | `tezos` release tag.                              | `v7-release`
+`image.tag`                     | `tezos` release tag.                              | `latest-release`
 `image.pullPolicy`              | Image pull policy                                 | `IfNotPresent`
 `service.rpcPort`               | RPC port                                          | `8732`
 `service.p2pPort`               | P2P port                                          | `9732`

--- a/charts/tezos/values.yaml
+++ b/charts/tezos/values.yaml
@@ -4,7 +4,7 @@
 terminationGracePeriodSeconds: 30
 image:
   repository: tezos/tezos
-  tag: v7-release
+  tag: latest-release
   pullPolicy: Always
 
 service:


### PR DESCRIPTION
Default version is very outdated, should use `latest-release` tag.

https://hub.docker.com/r/tezos/tezos